### PR TITLE
Remove incorrect attribution to IBM in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nj
 
-This is a cut-down version of IBM's [Eclipse OMR](https://github.com/eclipse/omr) project focussing just on the compiler / JIT backend. 
+This is a cut-down version of the [Eclipse OMR](https://github.com/eclipse/omr) project focussing just on the compiler / JIT backend. 
 
 Here is what is included:
 


### PR DESCRIPTION
Eclipse OMR is an Eclipse Foundation project. Regardless of its origins,
it should not be referred to as IBM's.

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>